### PR TITLE
Make authorizer independent from the webapp server

### DIFF
--- a/mitzu/webapp/dependencies.py
+++ b/mitzu/webapp/dependencies.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from flask import Flask
 
 import mitzu.webapp.auth.authorizer as A
 import mitzu.webapp.cache as C
@@ -26,7 +25,7 @@ class Dependencies:
     user_service: Optional[U.UserService] = None
 
     @classmethod
-    def from_configs(cls, server: Flask) -> Dependencies:
+    def from_configs(cls) -> Dependencies:
         delegate_cache: C.MitzuCache
         if configs.STORAGE_REDIS_HOST is not None:
             delegate_cache = C.RedisMitzuCache(global_prefix=configs.CACHE_PREFIX)
@@ -68,7 +67,6 @@ class Dependencies:
                 user_service=user_service,
             )
             authorizer = A.OAuthAuthorizer.create(auth_config)
-            authorizer.setup_authorizer(server)
 
         queue: C.MitzuCache
         if configs.QUEUE_REDIS_HOST is not None:

--- a/mitzu/webapp/webapp.py
+++ b/mitzu/webapp/webapp.py
@@ -72,7 +72,9 @@ def create_dash_app(dependencies: Optional[DEPS.Dependencies] = None) -> Dash:
         @server.after_request
         def after_request(response: flask.Response):
             request = flask.request
-            return dependencies.authorizer.refresh_auth_token(request, response)
+            if dependencies is not None and dependencies.authorizer is not None:
+                return dependencies.authorizer.refresh_auth_token(request, response)
+            return response
 
     with server.app_context():
         flask.current_app.config[DEPS.CONFIG_KEY] = dependencies

--- a/mitzu/webapp/webapp.py
+++ b/mitzu/webapp/webapp.py
@@ -60,7 +60,19 @@ def get_callback_manager(dependencies: DEPS.Dependencies) -> BaseLongCallbackMan
 def create_dash_app(dependencies: Optional[DEPS.Dependencies] = None) -> Dash:
     server = flask.Flask(__name__)
     if dependencies is None:
-        dependencies = DEPS.Dependencies.from_configs(server)
+        dependencies = DEPS.Dependencies.from_configs()
+
+    if dependencies.authorizer is not None:
+
+        @server.before_request
+        def before_request():
+            request = flask.request
+            return dependencies.authorizer.authorize_request(request)
+
+        @server.after_request
+        def after_request(response: flask.Response):
+            request = flask.request
+            return dependencies.authorizer.refresh_auth_token(request, response)
 
     with server.app_context():
         flask.current_app.config[DEPS.CONFIG_KEY] = dependencies


### PR DESCRIPTION
The webapp's flask server was passed to the authorizer instance to configure the hooks. This caused an unnecessary dependency between the webapp and the dependencies instance and it's a bit better when the dependencies just contains the dependencies and the webapp can decide how it should use them.