### PR TITLE
Global navbar item list

### DIFF
--- a/mitzu/webapp/dependencies.py
+++ b/mitzu/webapp/dependencies.py
@@ -9,6 +9,7 @@ import mitzu.webapp.cache as C
 import mitzu.webapp.configs as configs
 import mitzu.webapp.storage as S
 import mitzu.webapp.service.user_service as U
+import mitzu.webapp.service.navbar_service as NB
 import mitzu.webapp.service.events_service as E
 
 CONFIG_KEY = "dependencies"
@@ -22,6 +23,7 @@ class Dependencies:
     queue: C.MitzuCache
     cache: C.MitzuCache
     events_service: E.EventsService
+    navbar_service: NB.NavbarService
     user_service: Optional[U.UserService] = None
 
     @classmethod
@@ -89,5 +91,6 @@ class Dependencies:
             storage=storage,
             queue=queue,
             user_service=user_service,
+            navbar_service=NB.NavbarService(),
             events_service=events_service,
         )

--- a/mitzu/webapp/navbar.py
+++ b/mitzu/webapp/navbar.py
@@ -16,7 +16,7 @@ OFF_CANVAS_TOGGLER = "off-canvas-toggler"
 
 def create_explore_button_col(
     storage: Optional[S.MitzuStorage] = None, project_name: Optional[str] = None
-):
+) -> bc.Component:
     if storage is None:
         storage = cast(
             DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
@@ -24,57 +24,111 @@ def create_explore_button_col(
 
     project_ids = storage.list_projects()
     projects = [storage.get_project(p_id) for p_id in project_ids]
-    return dbc.Col(
-        dbc.DropdownMenu(
-            children=[
-                dbc.DropdownMenuItem(
-                    children=p.project_name,
-                    href=P.create_path(P.PROJECTS_EXPLORE_PATH, project_id=p.id),
-                )
-                for p in projects
-            ],
-            size="sm",
-            color="light",
-            label="explore" if project_name is None else project_name,
-            class_name="d-inline-block",
-        ),
-        width="auto",
+    return dbc.DropdownMenu(
+        children=[
+            dbc.DropdownMenuItem(
+                children=p.project_name,
+                href=P.create_path(P.PROJECTS_EXPLORE_PATH, project_id=p.id),
+            )
+            for p in projects
+        ],
+        size="sm",
+        color="light",
+        label="explore" if project_name is None else project_name,
+        class_name="d-inline-block",
     )
+
+
+LEFT_NAVBAR_ITEM_PROVIDERS: List[bc.Component] = []
+RIGHT_NAVBAR_ITEM_PROVIDERS: List[bc.Component] = []
+
+
+def init_navbar_item_providers():
+    def off_canvas_toggle(id: str, **kwargs) -> Optional[bc.Component]:
+        off_canvas_toggler_visible = kwargs.get("off_canvas_toggler_visible", True)
+        return dbc.Button(
+            html.B(className="bi bi-list"),
+            color="primary",
+            size="sm",
+            className="me-3",
+            id={"type": OFF_CANVAS_TOGGLER, "index": id},
+            style={"display": "inline-block" if off_canvas_toggler_visible else "none"},
+        )
+
+    def explore_button(id: str, **kwargs) -> Optional[bc.Component]:
+        create_explore_button = kwargs.get("create_explore_button", True)
+        storage = kwargs.get("storage", None)
+        project_name = kwargs.get("project_name", None)
+        if create_explore_button:
+            return create_explore_button_col(storage, project_name)
+        return None
+
+    global LEFT_NAVBAR_ITEM_PROVIDERS
+    LEFT_NAVBAR_ITEM_PROVIDERS = [
+        off_canvas_toggle,
+        explore_button,
+    ]
+
+    def signed_in_as(id: str, **kwargs) -> Optional[bc.Component]:
+        authorizer = cast(
+            DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
+        ).authorizer
+
+        storage = cast(
+            DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
+        ).storage
+
+        if authorizer is None:
+            return None
+
+        user_id = authorizer.get_current_user_id()
+        if user_id is None:
+            return None
+
+        email = None
+        if storage:
+            user = storage.get_user_by_id(user_id)
+            if user:
+                email = user.email
+        if email is None:
+            email = user_id
+
+        return html.Div(
+            "Signed in as " + email,
+            style={"color": "white", "line-height": "2.4em", "font-weight": "bold"},
+        )
+
+    global RIGHT_NAVBAR_ITEM_PROVIDERS
+    RIGHT_NAVBAR_ITEM_PROVIDERS = [
+        signed_in_as,
+    ]
 
 
 def create_mitzu_navbar(
     id: str,
     children: List[bc.Component] = [],
-    storage: Optional[S.MitzuStorage] = None,
-    create_explore_button: bool = True,
-    off_canvas_toggler_visible: bool = True,
-    project_name: Optional[str] = None,
+    **kwargs,
 ) -> dbc.Navbar:
+    navbar_comps = []
 
-    navbar_children = [
-        dbc.Col(
-            dbc.Button(
-                html.B(className="bi bi-list"),
-                color="primary",
-                size="sm",
-                className="me-3",
-                id={"type": OFF_CANVAS_TOGGLER, "index": id},
-                style={
-                    "display": "inline-block" if off_canvas_toggler_visible else "none"
-                },
-            ),
-            width="auto",
-        ),
-    ]
-    if create_explore_button:
-        navbar_children.append(create_explore_button_col(storage, project_name))
+    for provider in LEFT_NAVBAR_ITEM_PROVIDERS:
+        comp = provider(id, **kwargs)
+        if comp is not None:
+            navbar_comps.append(comp)
 
-    navbar_children.extend([dbc.Col(comp) for comp in children])
+    for comp in children:
+        navbar_comps.append(comp)
+
+    for provider in RIGHT_NAVBAR_ITEM_PROVIDERS:
+        comp = provider(id, **kwargs)
+        if comp is not None:
+            navbar_comps.append(comp)
+
     res = dbc.Navbar(
         dbc.Container(
             [
                 dbc.Row(
-                    children=navbar_children,
+                    children=[dbc.Col(comp, width="auto") for comp in navbar_comps],
                     className="g-2",
                 ),
             ],

--- a/mitzu/webapp/navbar.py
+++ b/mitzu/webapp/navbar.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
-import dash.development.base_component as bc
 
 import dash_bootstrap_components as dbc
-from typing import List, cast
+from typing import cast
 import flask
 import mitzu.webapp.dependencies as DEPS
 
 
 def create_mitzu_navbar(
     id: str,
-    children: List[bc.Component] = [],
     **kwargs,
 ) -> dbc.Navbar:
     navbar_service = cast(
         DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
     ).navbar_service
-    return navbar_service.get_navbar_component(id, children, **kwargs)
+    return navbar_service.get_navbar_component(id, **kwargs)

--- a/mitzu/webapp/navbar.py
+++ b/mitzu/webapp/navbar.py
@@ -3,105 +3,9 @@ from __future__ import annotations
 import dash.development.base_component as bc
 
 import dash_bootstrap_components as dbc
-from dash import html
-from typing import List, Optional, cast
-import mitzu.webapp.storage as S
-import mitzu.webapp.pages.paths as P
+from typing import List, cast
 import flask
 import mitzu.webapp.dependencies as DEPS
-
-
-OFF_CANVAS_TOGGLER = "off-canvas-toggler"
-
-
-def create_explore_button_col(
-    storage: Optional[S.MitzuStorage] = None, project_name: Optional[str] = None
-) -> bc.Component:
-    if storage is None:
-        storage = cast(
-            DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
-        ).storage
-
-    project_ids = storage.list_projects()
-    projects = [storage.get_project(p_id) for p_id in project_ids]
-    return dbc.DropdownMenu(
-        children=[
-            dbc.DropdownMenuItem(
-                children=p.project_name,
-                href=P.create_path(P.PROJECTS_EXPLORE_PATH, project_id=p.id),
-            )
-            for p in projects
-        ],
-        size="sm",
-        color="light",
-        label="explore" if project_name is None else project_name,
-        class_name="d-inline-block",
-    )
-
-
-LEFT_NAVBAR_ITEM_PROVIDERS: List[bc.Component] = []
-RIGHT_NAVBAR_ITEM_PROVIDERS: List[bc.Component] = []
-
-
-def init_navbar_item_providers():
-    def off_canvas_toggle(id: str, **kwargs) -> Optional[bc.Component]:
-        off_canvas_toggler_visible = kwargs.get("off_canvas_toggler_visible", True)
-        return dbc.Button(
-            html.B(className="bi bi-list"),
-            color="primary",
-            size="sm",
-            className="me-3",
-            id={"type": OFF_CANVAS_TOGGLER, "index": id},
-            style={"display": "inline-block" if off_canvas_toggler_visible else "none"},
-        )
-
-    def explore_button(id: str, **kwargs) -> Optional[bc.Component]:
-        create_explore_button = kwargs.get("create_explore_button", True)
-        storage = kwargs.get("storage", None)
-        project_name = kwargs.get("project_name", None)
-        if create_explore_button:
-            return create_explore_button_col(storage, project_name)
-        return None
-
-    global LEFT_NAVBAR_ITEM_PROVIDERS
-    LEFT_NAVBAR_ITEM_PROVIDERS = [
-        off_canvas_toggle,
-        explore_button,
-    ]
-
-    def signed_in_as(id: str, **kwargs) -> Optional[bc.Component]:
-        authorizer = cast(
-            DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
-        ).authorizer
-
-        storage = cast(
-            DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
-        ).storage
-
-        if authorizer is None:
-            return None
-
-        user_id = authorizer.get_current_user_id()
-        if user_id is None:
-            return None
-
-        email = None
-        if storage:
-            user = storage.get_user_by_id(user_id)
-            if user:
-                email = user.email
-        if email is None:
-            email = user_id
-
-        return html.Div(
-            "Signed in as " + email,
-            style={"color": "white", "line-height": "2.4em", "font-weight": "bold"},
-        )
-
-    global RIGHT_NAVBAR_ITEM_PROVIDERS
-    RIGHT_NAVBAR_ITEM_PROVIDERS = [
-        signed_in_as,
-    ]
 
 
 def create_mitzu_navbar(
@@ -109,33 +13,7 @@ def create_mitzu_navbar(
     children: List[bc.Component] = [],
     **kwargs,
 ) -> dbc.Navbar:
-    navbar_comps = []
-
-    for provider in LEFT_NAVBAR_ITEM_PROVIDERS:
-        comp = provider(id, **kwargs)
-        if comp is not None:
-            navbar_comps.append(comp)
-
-    for comp in children:
-        navbar_comps.append(comp)
-
-    for provider in RIGHT_NAVBAR_ITEM_PROVIDERS:
-        comp = provider(id, **kwargs)
-        if comp is not None:
-            navbar_comps.append(comp)
-
-    res = dbc.Navbar(
-        dbc.Container(
-            [
-                dbc.Row(
-                    children=[dbc.Col(comp, width="auto") for comp in navbar_comps],
-                    className="g-2",
-                ),
-            ],
-            fluid=True,
-        ),
-        class_name="mb-3",
-        color="dark",
-    )
-
-    return res
+    navbar_service = cast(
+        DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
+    ).navbar_service
+    return navbar_service.get_navbar_component(id, children, **kwargs)

--- a/mitzu/webapp/offcanvas.py
+++ b/mitzu/webapp/offcanvas.py
@@ -10,7 +10,7 @@ from mitzu import __version__ as version
 
 import mitzu.webapp.configs as configs
 import mitzu.webapp.dependencies as DEPS
-import mitzu.webapp.navbar as NB
+import mitzu.webapp.service.navbar_service as NB
 import mitzu.webapp.pages.paths as P
 from mitzu.webapp.auth.decorator import restricted
 

--- a/mitzu/webapp/pages/connections_page.py
+++ b/mitzu/webapp/pages/connections_page.py
@@ -31,7 +31,7 @@ def layout() -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("explore-navbar", []),
+            NB.create_mitzu_navbar("explore-navbar"),
             dbc.Container(
                 children=[
                     html.H4("Choose from connections:", className="card-title"),

--- a/mitzu/webapp/pages/dashboards.py
+++ b/mitzu/webapp/pages/dashboards.py
@@ -43,7 +43,7 @@ def layout(**query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("dashboard-navbar", []),
+            NB.create_mitzu_navbar("dashboard-navbar"),
             dbc.Container(
                 children=[
                     dbc.Row(

--- a/mitzu/webapp/pages/edit_user.py
+++ b/mitzu/webapp/pages/edit_user.py
@@ -86,7 +86,7 @@ def layout(user_id: str, **query_params) -> bc.Component:
     if user is None and user_id != "new":
         return html.Div(
             [
-                NB.create_mitzu_navbar("users_edit", []),
+                NB.create_mitzu_navbar("users_edit"),
                 dbc.Container(
                     [
                         html.H4("Users not found"),
@@ -105,7 +105,7 @@ def layout(user_id: str, **query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("users_management_page", []),
+            NB.create_mitzu_navbar("users_management_page"),
             dbc.Container(
                 [
                     html.H4("User"),

--- a/mitzu/webapp/pages/explore/explore_page.py
+++ b/mitzu/webapp/pages/explore/explore_page.py
@@ -79,29 +79,44 @@ ALL_INPUT_COMPS = {
 }
 
 
-def create_navbar(
-    metric: Optional[M.Metric],
-    saved_metric: Optional[WM.SavedMetric],
-    project: M.Project,
-    notebook_mode: bool,
-) -> dbc.Navbar:
-    navbar_children = [
-        MTH.from_metric_type(MTH.MetricType.from_metric(metric)),
-        dmc.TextInput(
-            id=METRIC_NAME_INPUT,
-            debounce=700,
-            placeholder="Name your metric",
-            value=saved_metric.name if saved_metric is not None else None,
+def metric_type_navbar_provider(
+    id: str, show_metric_type: bool = False, metric: Optional[M.Metric] = None, **kwargs
+) -> Optional[bc.Component]:
+    if not show_metric_type:
+        return None
+    return MTH.from_metric_type(MTH.MetricType.from_metric(metric))
+
+
+def metric_name_navbar_provider(
+    id: str,
+    show_metric_name: bool = False,
+    saved_metric: Optional[WM.SavedMetric] = None,
+    **kwargs,
+) -> Optional[bc.Component]:
+    if not show_metric_name:
+        return None
+
+    return dmc.TextInput(
+        id=METRIC_NAME_INPUT,
+        debounce=700,
+        placeholder="Name your metric",
+        value=saved_metric.name if saved_metric is not None else None,
+        size="xs",
+        icon=DashIconify(icon="material-symbols:star", color="dark"),
+        rightSection=dmc.Loader(
             size="xs",
-            icon=DashIconify(icon="material-symbols:star", color="dark"),
-            rightSection=dmc.Loader(
-                size="xs",
-                color="dark",
-                className="d-none",
-                id=METRIC_NAME_PROGRESS,
-            ),
-            style={"width": "200px"},
+            color="dark",
+            className="d-none",
+            id=METRIC_NAME_PROGRESS,
         ),
+        style={"width": "200px"},
+    )
+
+
+def share_button_navbar_provider(
+    id: str, notebook_mode: bool = True, **kwargs
+) -> Optional[bc.Component]:
+    return (
         dbc.Button(
             [
                 html.B(className="bi bi-link-45deg"),
@@ -118,13 +133,6 @@ def create_navbar(
             size="sm",
             style={"display": "none" if notebook_mode else "inline-block"},
         ),
-    ]
-
-    return NB.create_mitzu_navbar(
-        id=NAVBAR_ID,
-        children=navbar_children,
-        off_canvas_toggler_visible=not notebook_mode,
-        project_name=project.project_name,
     )
 
 
@@ -148,10 +156,12 @@ def create_explore_page(
 
     metric_segments_div = MS.from_metric(metric, discovered_project)
     graph_container = create_graph_container(metric, discovered_project.project)
-    navbar = create_navbar(
+    navbar = NB.create_mitzu_navbar(
+        id=NAVBAR_ID,
+        show_metric_type=True,
+        show_metric_name=True,
         metric=metric,
         saved_metric=saved_metric,
-        project=discovered_project.project,
         notebook_mode=notebook_mode,
     )
 

--- a/mitzu/webapp/pages/home.py
+++ b/mitzu/webapp/pages/home.py
@@ -18,7 +18,7 @@ register_page(
 def layout(**query_params):
     return html.Div(
         [
-            NB.create_mitzu_navbar("home-navbar", []),
+            NB.create_mitzu_navbar("home-navbar"),
             dbc.Container(
                 children=[
                     dbc.Row(

--- a/mitzu/webapp/pages/manage_connection.py
+++ b/mitzu/webapp/pages/manage_connection.py
@@ -47,7 +47,7 @@ def layout(connection_id: Optional[str] = None, **query_params) -> bc.Component:
 
     return dbc.Form(
         [
-            NB.create_mitzu_navbar("create-connection-navbar", []),
+            NB.create_mitzu_navbar("create-connection-navbar"),
             dbc.Container(
                 children=[
                     html.H4(title),

--- a/mitzu/webapp/pages/manage_dashboard.py
+++ b/mitzu/webapp/pages/manage_dashboard.py
@@ -28,7 +28,7 @@ def layout(dashboard_id: Optional[str] = None, **query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("create-dashboard-navbar", []),
+            NB.create_mitzu_navbar("create-dashboard-navbar"),
             MDC.create_manage_dashboard_container(dashboard),
         ]
     )

--- a/mitzu/webapp/pages/manage_event_defs.py
+++ b/mitzu/webapp/pages/manage_event_defs.py
@@ -105,7 +105,7 @@ def layout(project_id: Optional[str], **query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("events-navbar", []),
+            NB.create_mitzu_navbar("events-navbar"),
             dbc.Container(
                 [
                     html.H4("Discovered events and properties"),

--- a/mitzu/webapp/pages/manage_project.py
+++ b/mitzu/webapp/pages/manage_project.py
@@ -148,7 +148,7 @@ def layout(project_id: Optional[str] = None, **query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("create-project-navbar", []),
+            NB.create_mitzu_navbar("create-project-navbar"),
             dbc.Container(
                 children=[
                     dbc.Row(

--- a/mitzu/webapp/pages/manage_saved_metrics.py
+++ b/mitzu/webapp/pages/manage_saved_metrics.py
@@ -209,7 +209,7 @@ def layout(**query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("saved_metrics_navbar", [], storage),
+            NB.create_mitzu_navbar("saved_metrics_navbar", storage=storage),
             dbc.Container(
                 [
                     html.H4("Saved metrics"),

--- a/mitzu/webapp/pages/projects_page.py
+++ b/mitzu/webapp/pages/projects_page.py
@@ -28,7 +28,7 @@ def layout(**query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("explore-navbar", []),
+            NB.create_mitzu_navbar("explore-navbar"),
             dbc.Container(
                 children=[
                     dbc.Row(

--- a/mitzu/webapp/pages/users.py
+++ b/mitzu/webapp/pages/users.py
@@ -85,7 +85,7 @@ def layout(**query_params) -> bc.Component:
 
     return html.Div(
         [
-            NB.create_mitzu_navbar("users_list", []),
+            NB.create_mitzu_navbar("users_list"),
             dbc.Container(
                 [
                     html.H4("Registered Users"),

--- a/mitzu/webapp/service/navbar_service.py
+++ b/mitzu/webapp/service/navbar_service.py
@@ -105,6 +105,7 @@ class NavbarService:
         self, id: str, children: List[bc.Component] = [], **kwargs
     ) -> dbc.Navbar:
         navbar_comps = []
+        right_navbar_comps = []
 
         for provider in self._left_navbar_providers:
             comp = provider(id, **kwargs)
@@ -117,7 +118,7 @@ class NavbarService:
         for provider in self._right_navbar_provider:
             comp = provider(id, **kwargs)
             if comp is not None:
-                navbar_comps.append(comp)
+                right_navbar_comps.append(comp)
 
         res = dbc.Navbar(
             dbc.Container(
@@ -125,6 +126,9 @@ class NavbarService:
                     dbc.Row(
                         children=[dbc.Col(comp, width="auto") for comp in navbar_comps],
                         className="g-2",
+                    ),
+                    dbc.Row(
+                        children=[dbc.Col(comp, width="autho") for comp in right_navbar_comps],
                     ),
                 ],
                 fluid=True,

--- a/mitzu/webapp/service/navbar_service.py
+++ b/mitzu/webapp/service/navbar_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import dash.development.base_component as bc
+
+import dash_bootstrap_components as dbc
+from dash import html
+from typing import List, Optional, cast
+import mitzu.webapp.pages.paths as P
+import flask
+import mitzu.webapp.dependencies as DEPS
+
+
+OFF_CANVAS_TOGGLER = "off-canvas-toggler"
+
+
+class NavbarService:
+    def __init__(self):
+        self._left_navbar_providers = []
+        self._right_navbar_provider = []
+
+        self._init_default_navbars()
+
+    def _init_default_navbars(self):
+        def off_canvas_toggle(id: str, **kwargs) -> Optional[bc.Component]:
+            off_canvas_toggler_visible = kwargs.get("off_canvas_toggler_visible", True)
+            return dbc.Button(
+                html.B(className="bi bi-list"),
+                color="primary",
+                size="sm",
+                className="me-3",
+                id={"type": OFF_CANVAS_TOGGLER, "index": id},
+                style={
+                    "display": "inline-block" if off_canvas_toggler_visible else "none"
+                },
+            )
+
+        def explore_button(id: str, **kwargs) -> Optional[bc.Component]:
+            create_explore_button = kwargs.get("create_explore_button", True)
+            storage = kwargs.get("storage", None)
+            project_name = kwargs.get("project_name", None)
+            if create_explore_button:
+                if storage is None:
+                    storage = cast(
+                        DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
+                    ).storage
+
+                project_ids = storage.list_projects()
+                projects = [storage.get_project(p_id) for p_id in project_ids]
+                return dbc.DropdownMenu(
+                    children=[
+                        dbc.DropdownMenuItem(
+                            children=p.project_name,
+                            href=P.create_path(
+                                P.PROJECTS_EXPLORE_PATH, project_id=p.id
+                            ),
+                        )
+                        for p in projects
+                    ],
+                    size="sm",
+                    color="light",
+                    label="explore" if project_name is None else project_name,
+                    class_name="d-inline-block",
+                )
+            return None
+
+        self._left_navbar_providers = [
+            off_canvas_toggle,
+            explore_button,
+        ]
+
+        def signed_in_as(id: str, **kwargs) -> Optional[bc.Component]:
+            authorizer = cast(
+                DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
+            ).authorizer
+
+            storage = cast(
+                DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
+            ).storage
+
+            if authorizer is None:
+                return None
+
+            user_id = authorizer.get_current_user_id()
+            if user_id is None:
+                return None
+
+            email = None
+            if storage:
+                user = storage.get_user_by_id(user_id)
+                if user:
+                    email = user.email
+            if email is None:
+                email = user_id
+
+            return html.Div(
+                "Signed in as " + email,
+                style={"color": "white", "line-height": "2.4em", "font-weight": "bold"},
+            )
+
+        self._right_navbar_provider = [
+            signed_in_as,
+        ]
+
+    def get_navbar_component(
+        self, id: str, children: List[bc.Component] = [], **kwargs
+    ) -> dbc.Navbar:
+        navbar_comps = []
+
+        for provider in self._left_navbar_providers:
+            comp = provider(id, **kwargs)
+            if comp is not None:
+                navbar_comps.append(comp)
+
+        for comp in children:
+            navbar_comps.append(comp)
+
+        for provider in self._right_navbar_provider:
+            comp = provider(id, **kwargs)
+            if comp is not None:
+                navbar_comps.append(comp)
+
+        res = dbc.Navbar(
+            dbc.Container(
+                [
+                    dbc.Row(
+                        children=[dbc.Col(comp, width="auto") for comp in navbar_comps],
+                        className="g-2",
+                    ),
+                ],
+                fluid=True,
+            ),
+            class_name="mb-3",
+            color="dark",
+        )
+
+        return res

--- a/mitzu/webapp/webapp.py
+++ b/mitzu/webapp/webapp.py
@@ -10,6 +10,7 @@ from dash.long_callback.managers import BaseLongCallbackManager
 
 import mitzu.webapp.configs as configs
 import mitzu.webapp.dependencies as DEPS
+import mitzu.webapp.navbar as NB
 import mitzu.webapp.storage as S
 import mitzu.webapp.offcanvas as OC
 from mitzu.helper import LOGGER
@@ -103,6 +104,7 @@ def create_dash_app(dependencies: Optional[DEPS.Dependencies] = None) -> Dash:
         ],
     )
     app._favicon = configs.DASH_FAVICON_PATH
+    NB.init_navbar_item_providers()
     app.layout = create_webapp_layout(dependencies)
 
     @server.route(configs.HEALTH_CHECK_PATH)

--- a/mitzu/webapp/webapp.py
+++ b/mitzu/webapp/webapp.py
@@ -12,6 +12,7 @@ import mitzu.webapp.configs as configs
 import mitzu.webapp.dependencies as DEPS
 import mitzu.webapp.storage as S
 import mitzu.webapp.offcanvas as OC
+import mitzu.webapp.pages.explore.explore_page as EXP
 from mitzu.helper import LOGGER
 
 from mitzu.webapp.helper import MITZU_LOCATION
@@ -80,6 +81,16 @@ def create_dash_app(dependencies: Optional[DEPS.Dependencies] = None) -> Dash:
         flask.current_app.config[DEPS.CONFIG_KEY] = dependencies
         if configs.SETUP_SAMPLE_PROJECT:
             S.setup_sample_project(dependencies.storage)
+
+    dependencies.navbar_service.register_navbar_item_provider(
+        "left", EXP.metric_type_navbar_provider
+    )
+    dependencies.navbar_service.register_navbar_item_provider(
+        "left", EXP.metric_name_navbar_provider
+    )
+    dependencies.navbar_service.register_navbar_item_provider(
+        "left", EXP.share_button_navbar_provider
+    )
 
     app = Dash(
         __name__,

--- a/mitzu/webapp/webapp.py
+++ b/mitzu/webapp/webapp.py
@@ -10,7 +10,6 @@ from dash.long_callback.managers import BaseLongCallbackManager
 
 import mitzu.webapp.configs as configs
 import mitzu.webapp.dependencies as DEPS
-import mitzu.webapp.navbar as NB
 import mitzu.webapp.storage as S
 import mitzu.webapp.offcanvas as OC
 from mitzu.helper import LOGGER
@@ -104,7 +103,6 @@ def create_dash_app(dependencies: Optional[DEPS.Dependencies] = None) -> Dash:
         ],
     )
     app._favicon = configs.DASH_FAVICON_PATH
-    NB.init_navbar_item_providers()
     app.layout = create_webapp_layout(dependencies)
 
     @server.route(configs.HEALTH_CHECK_PATH)

--- a/tests/unit/webapp/fixtures.py
+++ b/tests/unit/webapp/fixtures.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 import mitzu.webapp.dependencies as DEPS
 import mitzu.webapp.storage as S
 import mitzu.webapp.service.events_service as E
+import mitzu.webapp.service.navbar_service as NB
 import mitzu.model as M
 from mitzu.webapp.cache import MitzuCache
 import flask
@@ -50,6 +51,7 @@ def dependencies() -> DEPS.Dependencies:
         cache=cache,
         queue=queue,
         events_service=evt_service,
+        navbar_service=NB.NavbarService(),
         user_service=None,
     )
 

--- a/tests/unit/webapp/pages/test_edit_users_page.py
+++ b/tests/unit/webapp/pages/test_edit_users_page.py
@@ -10,6 +10,7 @@ import mitzu.webapp.auth.authorizer as A
 import mitzu.webapp.model as WM
 import mitzu.webapp.service.user_service as US
 import mitzu.webapp.service.events_service as ES
+import mitzu.webapp.service.navbar_service as NB
 import mitzu.webapp.pages.paths as P
 
 
@@ -56,6 +57,7 @@ class RequestContextLoggedInAsRootUser:
             cache=cache,
             user_service=user_service,
             events_service=event_service,
+            navbar_service=NB.NavbarService(),
         )
 
         self.context = self._server.test_request_context(


### PR DESCRIPTION
The current navbar items were too static and the create_mitzu_navbar arguments list started to grow and contain arguments used only once. Instead of hardcoding everything in the create_mitzu_navbar method let's start having navbar item providers which are simple functions getting the id of the navbar and the **kwargs. Later we can add new items dynamically, test these items separately.

Explore is the only page having some custom navigation bar items, later we need to find a nice way to register a new navbar item provider from the pages package.

![Screenshot from 2023-03-30 22-36-11](https://user-images.githubusercontent.com/5155866/228958471-c505c587-fe04-4e85-b13d-e58a72d55c1a.png)
![Screenshot from 2023-03-30 22-34-47](https://user-images.githubusercontent.com/5155866/228958485-e787b99c-8179-42b2-b903-5c2967e41ff3.png)
