### PR TITLE
Fix navbar service

### DIFF
--- a/mitzu/webapp/service/navbar_service.py
+++ b/mitzu/webapp/service/navbar_service.py
@@ -139,7 +139,7 @@ class NavbarService:
                     ),
                     dbc.Row(
                         children=[
-                            dbc.Col(comp, width="autho") for comp in right_navbar_comps
+                            dbc.Col(comp, width="auto") for comp in right_navbar_comps
                         ],
                     ),
                 ],

--- a/mitzu/webapp/service/navbar_service.py
+++ b/mitzu/webapp/service/navbar_service.py
@@ -4,7 +4,7 @@ import dash.development.base_component as bc
 
 import dash_bootstrap_components as dbc
 from dash import html
-from typing import Optional, cast
+from typing import Optional, cast, Callable, List, Tuple
 import mitzu.webapp.pages.paths as P
 import flask
 import mitzu.webapp.dependencies as DEPS
@@ -16,8 +16,8 @@ OFF_CANVAS_TOGGLER = "off-canvas-toggler"
 
 class NavbarService:
     def __init__(self):
-        self._left_navbar_providers = []
-        self._right_navbar_provider = []
+        self._left_navbar_providers: List[Tuple[int, Callable]] = []
+        self._right_navbar_providers: List[Tuple[int, Callable]] = []
 
         self._init_default_navbars()
 
@@ -69,8 +69,8 @@ class NavbarService:
             return None
 
         self._left_navbar_providers = [
-            off_canvas_toggle,
-            explore_button,
+            (0, off_canvas_toggle),
+            (10, explore_button),
         ]
 
         def signed_in_as(id: str, **kwargs) -> Optional[bc.Component]:
@@ -102,15 +102,17 @@ class NavbarService:
                 style={"color": "white", "line-height": "2.4em", "font-weight": "bold"},
             )
 
-        self._right_navbar_provider = [
-            signed_in_as,
+        self._right_navbar_providers = [
+            (50, signed_in_as),
         ]
 
-    def register_navbar_item_provider(self, menu_name: str, callback):
+    def register_navbar_item_provider(self, menu_name: str, callback, priority=100):
         if menu_name == "left":
-            self._left_navbar_providers.append(callback)
+            self._left_navbar_providers.append((priority, callback))
+            self._left_navbar_providers.sort(key=lambda x: x[0])
         elif menu_name == "right":
-            self._right_navbar_provider.append(callback)
+            self._right_navbar_providers.append((priority, callback))
+            self._right_navbar_providers.sort(key=lambda x: x[0])
         else:
             raise ValueError(f"Unknow navbar menu: {menu_name}")
 
@@ -118,12 +120,12 @@ class NavbarService:
         left_navbar_comps = []
         right_navbar_comps = []
 
-        for provider in self._left_navbar_providers:
+        for _, provider in self._left_navbar_providers:
             comp = provider(id, **kwargs)
             if comp is not None:
                 left_navbar_comps.append(comp)
 
-        for provider in self._right_navbar_provider:
+        for _, provider in self._right_navbar_providers:
             comp = provider(id, **kwargs)
             if comp is not None:
                 right_navbar_comps.append(comp)

--- a/mitzu/webapp/service/navbar_service.py
+++ b/mitzu/webapp/service/navbar_service.py
@@ -12,6 +12,8 @@ import mitzu.webapp.storage as S
 
 
 OFF_CANVAS_TOGGLER = "off-canvas-toggler"
+EXPLORE_DROPDOWN = "explore-dropdown"
+SIGNED_IN_AS_DIV = "signed-in-as"
 
 
 class NavbarService:
@@ -65,6 +67,7 @@ class NavbarService:
                     color="light",
                     label="explore" if project_name is None else project_name,
                     class_name="d-inline-block",
+                    id={"type": EXPLORE_DROPDOWN, "index": id},
                 )
             return None
 
@@ -100,6 +103,7 @@ class NavbarService:
             return html.Div(
                 "Signed in as " + email,
                 style={"color": "white", "line-height": "2.4em", "font-weight": "bold"},
+                id={"type": SIGNED_IN_AS_DIV, "index": id},
             )
 
         self._right_navbar_providers = [

--- a/mitzu/webapp/webapp.py
+++ b/mitzu/webapp/webapp.py
@@ -83,13 +83,19 @@ def create_dash_app(dependencies: Optional[DEPS.Dependencies] = None) -> Dash:
             S.setup_sample_project(dependencies.storage)
 
     dependencies.navbar_service.register_navbar_item_provider(
-        "left", EXP.metric_type_navbar_provider
+        "left",
+        EXP.metric_type_navbar_provider,
+        priority=20,
     )
     dependencies.navbar_service.register_navbar_item_provider(
-        "left", EXP.metric_name_navbar_provider
+        "left",
+        EXP.metric_name_navbar_provider,
+        priority=30,
     )
     dependencies.navbar_service.register_navbar_item_provider(
-        "left", EXP.share_button_navbar_provider
+        "left",
+        EXP.share_button_navbar_provider,
+        priority=40,
     )
 
     app = Dash(

--- a/tests/unit/webapp/service/test_navbar_service.py
+++ b/tests/unit/webapp/service/test_navbar_service.py
@@ -1,0 +1,78 @@
+import mitzu.webapp.service.navbar_service as NB
+import flask
+from dash import html
+from tests.unit.webapp.pages.test_edit_users_page import (
+    RequestContextLoggedInAsRootUser,
+)
+
+
+def test_navbar_service_registers_the_default_items(server: flask.Flask):
+    service = NB.NavbarService()
+    root_id = "root_id"
+
+    with RequestContextLoggedInAsRootUser(server):
+        navbar = service.get_navbar_component(root_id)
+        left_nav_bar_items = navbar.children.children[0].children
+        assert left_nav_bar_items[0].children.id == {
+            "type": NB.OFF_CANVAS_TOGGLER,
+            "index": root_id,
+        }
+        assert left_nav_bar_items[1].children.id == {
+            "type": NB.EXPLORE_DROPDOWN,
+            "index": root_id,
+        }
+        assert len(left_nav_bar_items) == 2
+
+        right_nav_bar_items = navbar.children.children[1].children
+        assert right_nav_bar_items[0].children.id == {
+            "type": NB.SIGNED_IN_AS_DIV,
+            "index": root_id,
+        }
+        assert len(right_nav_bar_items) == 1
+
+
+def test_navbar_service_adds_new_items_with_orders(server: flask.Flask):
+    service = NB.NavbarService()
+    root_id = "root_id"
+
+    def first(id: str, **kwargs):
+        return html.Div(
+            "first",
+            id={"type": "first", "index": id},
+        )
+
+    def last(id: str, **kwargs):
+        return html.Div(
+            "last",
+            id={"type": "last", "index": id},
+        )
+
+    service.register_navbar_item_provider("left", first, priority=5)
+    service.register_navbar_item_provider("left", last, priority=100)
+
+    service.register_navbar_item_provider("right", first, priority=10)
+    service.register_navbar_item_provider("right", last, priority=100)
+
+    with RequestContextLoggedInAsRootUser(server):
+        navbar = service.get_navbar_component(root_id)
+        left_nav_bar_items = navbar.children.children[0].children
+        assert left_nav_bar_items[0].children.id == {
+            "type": NB.OFF_CANVAS_TOGGLER,
+            "index": root_id,
+        }
+        assert left_nav_bar_items[1].children.id == {"type": "first", "index": root_id}
+        assert left_nav_bar_items[2].children.id == {
+            "type": NB.EXPLORE_DROPDOWN,
+            "index": root_id,
+        }
+        assert left_nav_bar_items[3].children.id == {"type": "last", "index": root_id}
+        assert len(left_nav_bar_items) == 4
+
+        right_nav_bar_items = navbar.children.children[1].children
+        assert right_nav_bar_items[0].children.id == {"type": "first", "index": root_id}
+        assert right_nav_bar_items[1].children.id == {
+            "type": NB.SIGNED_IN_AS_DIV,
+            "index": root_id,
+        }
+        assert right_nav_bar_items[2].children.id == {"type": "last", "index": root_id}
+        assert len(right_nav_bar_items) == 3


### PR DESCRIPTION
There was a typo preventing multiple items to be rendered next to each other in the right navbar menu.

Also we need to find a way to set the order of the registered navbar menu providers dynamically. We shouldn't rely on the order of the registration. To achieve this all item provider registration can have a priority argument and the navbar items will be sorted accordingly. The default ones are registered with a gap between their priorities so later we can add other items between these easily.