### PR TITLE
Fix token refresh on asset urls and token refresh rate

### DIFF
--- a/mitzu/webapp/auth/authorizer.py
+++ b/mitzu/webapp/auth/authorizer.py
@@ -110,6 +110,7 @@ class OAuthAuthorizer:
             P.SIGN_OUT_URL,
             P.HEALTHCHECK_PATH,
             "/assets/",
+            "/_dash-component-suites/",
         ]
     )
 


### PR DESCRIPTION
The auth token was refreshed unnecessarily when requesting some static assets.

The auth token was continuously refreshed when the dash was polling for the results of a background callback.