### PR TITLE
Do not cache the db session in the request context

### DIFF
--- a/mitzu/webapp/webapp.py
+++ b/mitzu/webapp/webapp.py
@@ -57,11 +57,7 @@ def create_dash_app(dependencies: Optional[DEPS.Dependencies] = None) -> Dash:
         deps: DEPS.Dependencies = cast(
             DEPS.Dependencies, flask.current_app.config.get(DEPS.CONFIG_KEY)
         )
-        resp = deps.authorizer.authorize_request(request)
-
-        # make sure there are no sessions left in the memory before dash forks a new worker
-        deps.storage._session.close_all()
-        return resp
+        return deps.authorizer.authorize_request(request)
 
     @server.after_request
     def after_request(response: flask.Response):

--- a/tests/unit/webapp/test_storage.py
+++ b/tests/unit/webapp/test_storage.py
@@ -1,5 +1,4 @@
 import pytest
-import flask
 from hypothesis import HealthCheck, given, settings
 import mitzu.webapp.storage as S
 from tests.unit.webapp.generators import (
@@ -10,8 +9,6 @@ from tests.unit.webapp.generators import (
     dashboard,
     MAX_EXAMPLES,
 )
-
-flask_app = flask.Flask(__name__)
 
 
 def create_storage() -> S.MitzuStorage:
@@ -25,23 +22,22 @@ def create_storage() -> S.MitzuStorage:
 def test_storing_connections(connection, updated_connection):
     object.__setattr__(updated_connection, "id", connection.id)
 
-    with flask_app.test_request_context():
-        storage = create_storage()
+    storage = create_storage()
 
-        assert len(storage.list_connections()) == 0
+    assert len(storage.list_connections()) == 0
 
-        storage.set_connection(connection.id, connection)
+    storage.set_connection(connection.id, connection)
 
-        assert storage.get_connection(connection.id) == connection
-        assert storage.list_connections() == [connection.id]
+    assert storage.get_connection(connection.id) == connection
+    assert storage.list_connections() == [connection.id]
 
-        storage.set_connection(connection.id, updated_connection)
-        assert storage.get_connection(connection.id) == updated_connection
+    storage.set_connection(connection.id, updated_connection)
+    assert storage.get_connection(connection.id) == updated_connection
 
-        storage.delete_connection(connection.id)
-        assert len(storage.list_connections()) == 0
-        with pytest.raises(ValueError):
-            storage.get_connection(connection.id)
+    storage.delete_connection(connection.id)
+    assert len(storage.list_connections()) == 0
+    with pytest.raises(ValueError):
+        storage.get_connection(connection.id)
 
 
 @given(project(), project())
@@ -52,54 +48,55 @@ def test_storing_connections(connection, updated_connection):
 )
 def test_storing_projects(project, updated_project):
     object.__setattr__(updated_project, "id", project.id)
-    with flask_app.test_request_context():
-        storage = create_storage()
+    storage = create_storage()
 
-        assert len(storage.list_projects()) == 0
+    assert len(storage.list_projects()) == 0
 
-        storage.set_project(project.id, project)
+    storage.set_project(project.id, project)
 
-        assert storage.get_project(project.id) == project
-        assert len(storage._get_event_data_tables_for_project(project.id)) == len(
-            project.event_data_tables
-        )
-        assert storage.list_projects() == [project.id]
+    assert storage.get_project(project.id) == project
+    with storage._new_db_session() as session:
+        assert len(
+            storage._get_event_data_tables_for_project(project.id, session)
+        ) == len(project.event_data_tables)
+    assert storage.list_projects() == [project.id]
 
-        storage.set_project(project.id, updated_project)
+    storage.set_project(project.id, updated_project)
 
-        assert storage.get_project(project.id) == updated_project
-        assert len(storage._get_event_data_tables_for_project(project.id)) == len(
-            updated_project.event_data_tables
-        )
+    assert storage.get_project(project.id) == updated_project
+    with storage._new_db_session() as session:
+        assert len(
+            storage._get_event_data_tables_for_project(project.id, session)
+        ) == len(updated_project.event_data_tables)
 
-        storage.delete_project(project.id)
-        assert len(storage.list_projects()) == 0
-        with pytest.raises(ValueError):
-            storage.get_project(project.id)
+    storage.delete_project(project.id)
+    assert len(storage.list_projects()) == 0
+    with pytest.raises(ValueError):
+        storage.get_project(project.id)
 
-        assert len(storage._get_event_data_tables_for_project(project.id)) == 0
+    with storage._new_db_session() as session:
+        assert len(storage._get_event_data_tables_for_project(project.id, session)) == 0
 
 
 @given(user(), user())
 @settings(deadline=None, max_examples=MAX_EXAMPLES)
 def test_storing_users(user, updated_user):
     object.__setattr__(updated_user, "id", user.id)
-    with flask_app.test_request_context():
-        storage = create_storage()
+    storage = create_storage()
 
-        assert len(storage.list_users()) == 0
+    assert len(storage.list_users()) == 0
 
-        storage.set_user(user)
+    storage.set_user(user)
 
-        assert storage.get_user_by_id(user.id) == user
-        assert storage.list_users() == [user]
+    assert storage.get_user_by_id(user.id) == user
+    assert storage.list_users() == [user]
 
-        storage.set_user(updated_user)
-        assert storage.get_user_by_id(user.id) == updated_user
+    storage.set_user(updated_user)
+    assert storage.get_user_by_id(user.id) == updated_user
 
-        storage.clear_user(user.id)
-        assert len(storage.list_users()) == 0
-        assert storage.get_user_by_id(user.id) is None
+    storage.clear_user(user.id)
+    assert len(storage.list_users()) == 0
+    assert storage.get_user_by_id(user.id) is None
 
 
 @given(saved_metric(), saved_metric())
@@ -112,25 +109,24 @@ def test_storing_saved_metrics(saved_metric, updated_saved_metric):
     object.__setattr__(updated_saved_metric, "id", saved_metric.id)
     object.__setattr__(updated_saved_metric, "_project_ref", saved_metric._project_ref)
 
-    with flask_app.test_request_context():
-        storage = create_storage()
-        storage.set_project(saved_metric.project.id, saved_metric.project)
+    storage = create_storage()
+    storage.set_project(saved_metric.project.id, saved_metric.project)
 
-        assert len(storage.list_saved_metrics()) == 0
+    assert len(storage.list_saved_metrics()) == 0
 
-        storage.set_saved_metric(saved_metric.id, saved_metric)
+    storage.set_saved_metric(saved_metric.id, saved_metric)
 
-        assert storage.get_saved_metric(saved_metric.id) == saved_metric
-        assert storage.list_saved_metrics() == [saved_metric.id]
+    assert storage.get_saved_metric(saved_metric.id) == saved_metric
+    assert storage.list_saved_metrics() == [saved_metric.id]
 
-        storage.set_saved_metric(saved_metric.id, updated_saved_metric)
+    storage.set_saved_metric(saved_metric.id, updated_saved_metric)
 
-        assert storage.get_saved_metric(saved_metric.id) == updated_saved_metric
+    assert storage.get_saved_metric(saved_metric.id) == updated_saved_metric
 
-        storage.clear_saved_metric(saved_metric.id)
-        assert len(storage.list_saved_metrics()) == 0
-        with pytest.raises(ValueError):
-            storage.get_saved_metric(saved_metric.id)
+    storage.clear_saved_metric(saved_metric.id)
+    assert len(storage.list_saved_metrics()) == 0
+    with pytest.raises(ValueError):
+        storage.get_saved_metric(saved_metric.id)
 
 
 @given(dashboard(), dashboard())
@@ -144,29 +140,28 @@ def test_storing_dashboards(dashboard, updated_dashboard):
     object.__setattr__(
         updated_dashboard, "dashboard_metrics", dashboard.dashboard_metrics
     )
-    with flask_app.test_request_context():
-        storage = create_storage()
-        for saved_dashboard_metric in [
-            dm.saved_metric
-            for dm in dashboard.dashboard_metrics + updated_dashboard.dashboard_metrics
-        ]:
-            storage.set_project(
-                saved_dashboard_metric.project.id, saved_dashboard_metric.project
-            )
-            storage.set_saved_metric(saved_dashboard_metric.id, saved_dashboard_metric)
+    storage = create_storage()
+    for saved_dashboard_metric in [
+        dm.saved_metric
+        for dm in dashboard.dashboard_metrics + updated_dashboard.dashboard_metrics
+    ]:
+        storage.set_project(
+            saved_dashboard_metric.project.id, saved_dashboard_metric.project
+        )
+        storage.set_saved_metric(saved_dashboard_metric.id, saved_dashboard_metric)
 
-        assert len(storage.list_dashboards()) == 0
+    assert len(storage.list_dashboards()) == 0
 
-        storage.set_dashboard(dashboard.id, dashboard)
+    storage.set_dashboard(dashboard.id, dashboard)
 
-        d = storage.get_dashboard(dashboard.id)
-        assert d.dashboard_metrics[0] == dashboard.dashboard_metrics[0]
-        assert d.dashboard_metrics == dashboard.dashboard_metrics
+    d = storage.get_dashboard(dashboard.id)
+    assert d.dashboard_metrics[0] == dashboard.dashboard_metrics[0]
+    assert d.dashboard_metrics == dashboard.dashboard_metrics
 
-        assert storage.get_dashboard(dashboard.id) == dashboard
-        assert storage.list_dashboards() == [dashboard.id]
+    assert storage.get_dashboard(dashboard.id) == dashboard
+    assert storage.list_dashboards() == [dashboard.id]
 
-        storage.clear_dashboard(dashboard.id)
-        assert len(storage.list_dashboards()) == 0
-        with pytest.raises(ValueError):
-            storage.get_dashboard(dashboard.id)
+    storage.clear_dashboard(dashboard.id)
+    assert len(storage.list_dashboards()) == 0
+    with pytest.raises(ValueError):
+        storage.get_dashboard(dashboard.id)


### PR DESCRIPTION
Caching the db session for each request has benefits but as it turned out recently when dash forks a process to serve a background call then it causes mysterious errors. Closing all sessions in time can be a good workaround but if there are multiple sessions in progress then we may close such a session which is needed by a different thread.

The new way of db session handling is to pass the session instance to the other storage methods when we want to make sure the calls are made within the same session.

hint: review without whitespace changes